### PR TITLE
Cycle episodes when navigating back and forth

### DIFF
--- a/app/assets/javascripts/episode.js.coffee.erb
+++ b/app/assets/javascripts/episode.js.coffee.erb
@@ -1,8 +1,8 @@
 subsequent_episode = () -> 
-  $('.subsequent_1')
+  if $('.subsequent_1').length then $('.subsequent_1') else $('.oldest_episode')
 
 previous_episode = () -> 
-  $('.previous_1')
+  if $('.previous_1').length then$('.previous_1') else $('.newest_episode')
 
 episode_url = (episode) -> $(episode).children().first().attr('href')
 


### PR DESCRIPTION
Hey, i noticed the site was on github so i looked through the code to fix a bug. I wasn't able to get the site running locally (only spent a few minutes), but the fix should work if you wanna pull it down and check.

Now the site shouldn't give an error if you navigate next when on the newest episode and previous when on the oldest episode.